### PR TITLE
Increase default cert validity from 2->5 yrs

### DIFF
--- a/scripts/generate-certs
+++ b/scripts/generate-certs
@@ -17,8 +17,7 @@ mv -f ${depot_path}/cert-authority.key ${depot_path}/server-ca.key
 # Certificate to use as the client
 server_cn=$2
 certstrap --depot-path ${depot_path} request-cert --passphrase '' --common-name $server_cn
-certstrap --depot-path ${depot_path} sign $server_cn --CA server-ca
+certstrap --depot-path ${depot_path} sign $server_cn --CA server-ca --years 5
 mv -f ${depot_path}/$server_cn.key ${depot_path}/server.key
 mv -f ${depot_path}/$server_cn.csr ${depot_path}/server.csr
 mv -f ${depot_path}/$server_cn.crt ${depot_path}/server.crt
-

--- a/scripts/generate-consul-certs
+++ b/scripts/generate-consul-certs
@@ -17,14 +17,14 @@ mv -f ${depot_path}/consulCA.key ${depot_path}/server-ca.key
 # Server certificate to share across the consul cluster
 server_cn=server.dc1.cf.internal
 certstrap --depot-path ${depot_path} request-cert --passphrase '' --common-name $server_cn
-certstrap --depot-path ${depot_path} sign $server_cn --CA server-ca
+certstrap --depot-path ${depot_path} sign $server_cn --CA server-ca --years 5
 mv -f ${depot_path}/$server_cn.key ${depot_path}/server.key
 mv -f ${depot_path}/$server_cn.csr ${depot_path}/server.csr
 mv -f ${depot_path}/$server_cn.crt ${depot_path}/server.crt
 
 # Agent certificate to distribute to jobs that access consul
 certstrap --depot-path ${depot_path} request-cert --passphrase '' --common-name 'consul agent'
-certstrap --depot-path ${depot_path} sign consul_agent --CA server-ca
+certstrap --depot-path ${depot_path} sign consul_agent --CA server-ca --years 5
 mv -f ${depot_path}/consul_agent.key ${depot_path}/agent.key
 mv -f ${depot_path}/consul_agent.csr ${depot_path}/agent.csr
 mv -f ${depot_path}/consul_agent.crt ${depot_path}/agent.crt

--- a/scripts/generate-dea-certs
+++ b/scripts/generate-dea-certs
@@ -18,11 +18,11 @@ mv -f ${depot_path}/deaCA.key ${depot_path}/dea_ca.key
 server_cn=dea.service.cf.internal
 server_domain='*.dea.service.cf.internal'
 certstrap --depot-path ${depot_path} request-cert --passphrase '' --common-name $server_cn --domain $server_domain
-certstrap --depot-path ${depot_path} sign $server_cn --CA dea_ca
+certstrap --depot-path ${depot_path} sign $server_cn --CA dea_ca --years 5
 mv -f ${depot_path}/$server_cn.key ${depot_path}/dea_server.key
 mv -f ${depot_path}/$server_cn.csr ${depot_path}/dea_server.csr
 mv -f ${depot_path}/$server_cn.crt ${depot_path}/dea_server.crt
 
 # Client certificate to distribute to jobs that access DEAs
 certstrap --depot-path ${depot_path} request-cert --passphrase '' --common-name 'dea client'
-certstrap --depot-path ${depot_path} sign dea_client --CA dea_ca
+certstrap --depot-path ${depot_path} sign dea_client --CA dea_ca --years 5

--- a/scripts/generate-etcd-certs
+++ b/scripts/generate-etcd-certs
@@ -16,14 +16,14 @@ mv -f ${depot_path}/etcdCA.key ${depot_path}/etcd-ca.key
 
 # Server certificate to share across the etcd cluster
 certstrap --depot-path ${depot_path} request-cert --passphrase '' --common-name cf-etcd.service.cf.internal --domain '*.cf-etcd.service.cf.internal,cf-etcd.service.cf.internal'
-certstrap --depot-path ${depot_path} sign cf-etcd.service.cf.internal --CA etcd-ca
+certstrap --depot-path ${depot_path} sign cf-etcd.service.cf.internal --CA etcd-ca --years 5
 mv -f ${depot_path}/cf-etcd.service.cf.internal.key ${depot_path}/server.key
 mv -f ${depot_path}/cf-etcd.service.cf.internal.csr ${depot_path}/server.csr
 mv -f ${depot_path}/cf-etcd.service.cf.internal.crt ${depot_path}/server.crt
 
 # Client certificate to distribute to jobs that access etcd
 certstrap --depot-path ${depot_path} request-cert --passphrase '' --common-name 'clientName'
-certstrap --depot-path ${depot_path} sign clientName --CA etcd-ca
+certstrap --depot-path ${depot_path} sign clientName --CA etcd-ca --years 5
 mv -f ${depot_path}/clientName.key ${depot_path}/client.key
 mv -f ${depot_path}/clientName.csr ${depot_path}/client.csr
 mv -f ${depot_path}/clientName.crt ${depot_path}/client.crt
@@ -35,7 +35,7 @@ mv -f ${depot_path}/peerCA.key ${depot_path}/peer-ca.key
 
 # Client certificate to distribute across etcd peers
 certstrap --depot-path ${depot_path} request-cert --passphrase '' --common-name cf-etcd.service.cf.internal --domain '*.cf-etcd.service.cf.internal,cf-etcd.service.cf.internal'
-certstrap --depot-path ${depot_path} sign cf-etcd.service.cf.internal --CA peer-ca
+certstrap --depot-path ${depot_path} sign cf-etcd.service.cf.internal --CA peer-ca --years 5
 mv -f ${depot_path}/cf-etcd.service.cf.internal.key ${depot_path}/peer.key
 mv -f ${depot_path}/cf-etcd.service.cf.internal.csr ${depot_path}/peer.csr
 mv -f ${depot_path}/cf-etcd.service.cf.internal.crt ${depot_path}/peer.crt

--- a/scripts/generate-hm9000-certs
+++ b/scripts/generate-hm9000-certs
@@ -18,11 +18,11 @@ mv -f ${depot_path}/hm9000CA.key ${depot_path}/hm9000_ca.key
 server_cn=listener-hm9000.service.cf.internal
 server_domain='*.listener-hm9000.service.cf.internal'
 certstrap --depot-path ${depot_path} request-cert --passphrase '' --common-name $server_cn --domain $server_domain,$server_cn
-certstrap --depot-path ${depot_path} sign $server_cn --CA hm9000_ca
+certstrap --depot-path ${depot_path} sign $server_cn --CA hm9000_ca --years 5
 mv -f ${depot_path}/$server_cn.key ${depot_path}/hm9000_server.key
 mv -f ${depot_path}/$server_cn.csr ${depot_path}/hm9000_server.csr
 mv -f ${depot_path}/$server_cn.crt ${depot_path}/hm9000_server.crt
 
 # Client certificate to distribute to jobs that access DEAs
-certstrap --depot-path ${depot_path} request-cert --passphrase '' --common-name 'hm9000_client' 
-certstrap --depot-path ${depot_path} sign hm9000_client --CA hm9000_ca
+certstrap --depot-path ${depot_path} request-cert --passphrase '' --common-name 'hm9000_client'
+certstrap --depot-path ${depot_path} sign hm9000_client --CA hm9000_ca --years 5


### PR DESCRIPTION
#### Why 
While signing the certificate, as of now certificate generation scripts are using default value of 2 yrs.
Being internal certificate , this value can be increased.
https://github.com/square/certstrap/blob/b6aef507a0840bf78bac99e7ffa6e6eb5c2c3c9f/cmd/sign.go#L38

#### Changes:
- Add years flag to certstrap with value 5.